### PR TITLE
docs: Fix simple typo, substiture -> substitute

### DIFF
--- a/paginate/__init__.py
+++ b/paginate/__init__.py
@@ -772,7 +772,7 @@ class Page(list):
 
     def _range(self, link_map, radius):
         """
-        Return range of linked pages to substiture placeholder in pattern
+        Return range of linked pages to substitute placeholder in pattern
         """
 
         leftmost_page = max(self.first_page, (self.page - radius))


### PR DESCRIPTION
There is a small typo in paginate/__init__.py.

Should read `substitute` rather than `substiture`.

